### PR TITLE
Validate action tests

### DIFF
--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -617,19 +617,7 @@ export class JobsController {
     @Body() createJobDto: CreateJobDto,
   ): Promise<JobClass | null> {
     Logger.log("Creating job!");
-    // throw an error if no jobParams are passed
-    if (
-      !createJobDto.jobParams ||
-      Object.keys(createJobDto.jobParams).length == 0
-    ) {
-      throw new HttpException(
-        {
-          status: HttpStatus.BAD_REQUEST,
-          message: "Job parameters need to be defined.",
-        },
-        HttpStatus.BAD_REQUEST,
-      );
-    }
+
     // Validate that request matches the current configuration
     // Check job authorization
     const jobInstance = await this.instanceAuthorizationJobCreate(

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -294,15 +294,15 @@ export class JobsController {
         HttpStatus.BAD_REQUEST,
       );
     }
-    if (datasetIds.length == 0) {
-      throw new HttpException(
-        {
-          status: HttpStatus.BAD_REQUEST,
-          message: "List of passed dataset IDs is empty.",
-        },
-        HttpStatus.BAD_REQUEST,
-      );
-    }
+    // if (datasetIds.length == 0) {
+    //   throw new HttpException(
+    //     {
+    //       status: HttpStatus.BAD_REQUEST,
+    //       message: "List of passed dataset IDs is empty.",
+    //     },
+    //     HttpStatus.BAD_REQUEST,
+    //   );
+    // }
 
     interface condition {
       where: {
@@ -604,6 +604,7 @@ export class JobsController {
    * Check for mismatches between the config version used to create the job and the currently loaded version.
    *
    * Currently this is only logged.
+   * @param jobConfig
    * @param jobInstance
    * @returns
    */

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -304,7 +304,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       });
   });
 
-  it("0065: Add a new job as a user from ADMIN_GROUPS for himself/herself in '#datasetPublic' configuration with empty jobParams parameter, which should fail", async () => {
+  it("0065: Add a new job as a user from ADMIN_GROUPS for himself/herself in '#datasetPublic' configuration with empty jobParams parameter", async () => {
     const newDataset = {
       type: "all_access",
       ownerUser: "admin",
@@ -318,11 +318,13 @@ describe("1100: Jobs: Test New Job Model", () => {
       .send(newDataset)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdmin}` })
-      .expect(TestData.BadRequestStatusCode)
+      .expect(TestData.EntryCreatedStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.not.have.property("id");
-        res.body.should.have.property("message").and.be.equal("Job parameters need to be defined.");
+        res.body.should.have.property("type").and.be.string;
+        res.body.should.have.property("ownerGroup").and.be.equal("admin");
+        res.body.should.have.property("ownerUser").and.be.equal("admin");
+        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
       });
   });
 
@@ -3406,7 +3408,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         .expect(TestData.SuccessfulGetStatusCode)
         .expect("Content-Type", /json/)
         .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(60);
+          res.body.should.be.an("array").to.have.lengthOf(61);
         });
   });
 
@@ -3421,7 +3423,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         .expect(TestData.SuccessfulGetStatusCode)
         .expect("Content-Type", /json/)
         .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(36);
+          res.body.should.be.an("array").to.have.lengthOf(37);
         });
   });
 
@@ -3827,7 +3829,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         .expect(TestData.SuccessfulGetStatusCode)
         .expect("Content-Type", /json/)
         .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(59);
+          res.body.should.be.an("array").to.have.lengthOf(60);
         });
   }); 
 

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -238,7 +238,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       });
   });
   
-  it("0040: Add a new job as a user from ADMIN_GROUPS for himself/herself in '#all' configuration with no datasets in job parameters, which should fail", async () => {
+  it("0040: Add a new job as a user from ADMIN_GROUPS for himself/herself in '#all' configuration with no datasets in job parameters, which should fail.", async () => {
     const newDataset = {
       ...jobAll,
       ownerUser: "admin",
@@ -258,7 +258,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.not.have.property("id")
-        res.body.should.have.property("message").and.be.equal("List of passed dataset IDs is empty.");
+        res.body.should.have.property("message").and.be.equal("Invalid request. Requires 'jobParams.datasetIds[0]'");
       });
   });
 
@@ -285,7 +285,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       });
   });
 
-  it("0060: Add a new job as a user from ADMIN_GROUPS for himself/herself in '#datasetPublic' configuration with no jobParams parameter, which should fail", async () => {
+  it("0060: Add a new job as a user from ADMIN_GROUPS for himself/herself in '#all' configuration with no jobParams parameter, which should fail", async () => {
     const newDataset = {
       type: "all_access",
       ownerUser: "admin",
@@ -304,9 +304,30 @@ describe("1100: Jobs: Test New Job Model", () => {
       });
   });
 
-  it("0065: Add a new job as a user from ADMIN_GROUPS for himself/herself in '#datasetPublic' configuration with empty jobParams parameter", async () => {
+  it("0065: Add a new job as a user from ADMIN_GROUPS for himself/herself in '#all' configuration with empty jobParams parameters, which should fail", async () => {
     const newDataset = {
       type: "all_access",
+      ownerUser: "admin",
+      ownerGroup: "admin",
+      jobParams: {
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Jobs")
+      .send(newDataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.BadRequestStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id")
+        res.body.should.have.property("message").and.be.equal("Invalid request. Requires 'jobParams.datasetIds[0]'");
+      });
+  });
+  it("0066: Add a new job as a user from ADMIN_GROUPS for himself/herself in '#datasetPupliv' configuration with empty jobParams parameter", async () => {
+    const newDataset = {
+      type: "public_access",
       ownerUser: "admin",
       ownerGroup: "admin",
       jobParams: {


### PR DESCRIPTION
## Description

There was an additional check implemented, that if a user passes a "datasetsIds" keyword then it was expecting a non-empty array of strings. I removed the check that it should be non-empty, as I suppose, the validator will now deal with that. 
I also added a few API tests to check that the `validate` function works correctly.
Also, merges a fix to issue #1411 allowing empty jobParams parameters. 